### PR TITLE
Add notice that repository is no longer being maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## No Longer Maintained
+
+This repository is no longer being maintained. Development for DistrictBuilder is continuing in https://github.com/PublicMapping/districtbuilder.
+
 Generates custom settings file for [DistrictBuilder](https://github.com/PublicMapping/DistrictBuilder) from `config.xml`.
 
 Also provides helpers for reading in config data and performs validation.


### PR DESCRIPTION
## Overview

Active development of this version of DistrictBuilder has ceased and is being continued in https://github.com/PublicMapping/districtbuilder. 